### PR TITLE
move created modules into right place

### DIFF
--- a/recipes-kernel/backports-laird/backports-laird_6.0.0.138.bb
+++ b/recipes-kernel/backports-laird/backports-laird_6.0.0.138.bb
@@ -20,3 +20,11 @@ do_compile_prepend() {
 	rm -f ${S}/.kernel_config_md5
 	oe_runmake CC=${BUILD_CC} defconfig-sterling60
 }
+
+do_install_append() {
+    # backports need to go into updates/ to be detected correctly
+    KD=`cd  ${D}/lib/modules; ls`
+    echo KV $KD
+    mkdir -v ${D}/lib/modules/${KD}/updates
+    mv -v ${D}/lib/modules/${KD}/{compat,drivers,net} ${D}/lib/modules/${KD}/updates
+}

--- a/recipes-kernel/backports-laird/backports-laird_6.0.0.138.bb
+++ b/recipes-kernel/backports-laird/backports-laird_6.0.0.138.bb
@@ -26,5 +26,5 @@ do_install_append() {
     KD=`cd  ${D}/lib/modules; ls`
     echo KV $KD
     mkdir -v ${D}/lib/modules/${KD}/updates
-    mv -v ${D}/lib/modules/${KD}/{compat,drivers,net} ${D}/lib/modules/${KD}/updates
+    mv -v ${D}/lib/modules/${KD}/[a-t]* ${D}/lib/modules/${KD}/updates
 }


### PR DESCRIPTION
the modules should go into /lib/modules/<kernel version>/updates in order to override the kernel modules.
Did not dig into your backports port, this is just a quick fix that works on our ARM boards (imx6/7 with kernel v4.9).